### PR TITLE
add nonce arg to cookie reauth

### DIFF
--- a/docs/Riot Auth/GET Cookie Reauth.md
+++ b/docs/Riot Auth/GET Cookie Reauth.md
@@ -6,4 +6,4 @@ Recommended to use this endpoint instead of storing the password and sending it 
 
 
 Method: `GET`  
-URL: `https://auth.riotgames.com/authorize?redirect_uri=https%3A%2F%2Fplayvalorant.com%2Fopt_in&client_id=play-valorant-web-prod&response_type=token%20id_token`  
+URL: `https://auth.riotgames.com/authorize?redirect_uri=https%3A%2F%2Fplayvalorant.com%2Fopt_in&client_id=play-valorant-web-prod&response_type=token%20id_token&nonce=1`  


### PR DESCRIPTION
Reauthing cookies now requires a `nonce` argument in the url