### PR TITLE
refactor: all endpoint use `as const` modifier

### DIFF
--- a/valorant-api-types/src/endpoints/auth/AuthCookies.ts
+++ b/valorant-api-types/src/endpoints/auth/AuthCookies.ts
@@ -11,4 +11,4 @@ export const authCookiesEndpoint = {
         ['Content-Type', 'application/json'],
     ]),
     body: '{"client_id":"play-valorant-web-prod","nonce":"1","redirect_uri":"https://playvalorant.com/opt_in","response_type":"token id_token","scope":"account openid"}'
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/auth/AuthRequest.ts
+++ b/valorant-api-types/src/endpoints/auth/AuthRequest.ts
@@ -19,4 +19,4 @@ export const authRequestEndpoint = {
         remember: z.boolean(),
         language: z.literal('en_US')
     })
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/auth/CookieReauth.ts
+++ b/valorant-api-types/src/endpoints/auth/CookieReauth.ts
@@ -8,4 +8,4 @@ export const cookieReauthEndpoint = {
     category: 'Authentication Endpoints',
     type: 'other',
     suffix: 'https://auth.riotgames.com/authorize?redirect_uri=https%3A%2F%2Fplayvalorant.com%2Fopt_in&client_id=play-valorant-web-prod&response_type=token%20id_token&nonce=1'
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/auth/Entitlement.ts
+++ b/valorant-api-types/src/endpoints/auth/Entitlement.ts
@@ -16,6 +16,6 @@ export const entitlementEndpoint = {
             entitlements_token: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type EntitlementResponse = z.input<typeof entitlementEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/auth/MultiFactorAuthentication.ts
+++ b/valorant-api-types/src/endpoints/auth/MultiFactorAuthentication.ts
@@ -16,4 +16,4 @@ export const multiFactorAuthenticationEndpoint = {
         code: z.string().describe('The multi-factor authentication code'),
         rememberDevice: z.boolean()
     })
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/auth/PlayerInfo.ts
+++ b/valorant-api-types/src/endpoints/auth/PlayerInfo.ts
@@ -41,6 +41,6 @@ export const playerInfoEndpoint = {
             affinity: z.record(z.string())
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PlayerInfoResponse = z.input<typeof playerInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/contracts/ActivateContract.ts
+++ b/valorant-api-types/src/endpoints/contracts/ActivateContract.ts
@@ -21,6 +21,6 @@ export const activateContractEndpoint = {
     responses: {
         '200': contractsResponse
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ActivateContractResponse = z.input<typeof activateContractEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/contracts/Contracts.ts
+++ b/valorant-api-types/src/endpoints/contracts/Contracts.ts
@@ -17,6 +17,6 @@ export const contractsEndpoint = {
     responses: {
         '200':contractsResponse
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ContractsResponse = z.input<typeof contractsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/contracts/ItemUpgrades.ts
+++ b/valorant-api-types/src/endpoints/contracts/ItemUpgrades.ts
@@ -59,6 +59,6 @@ export const itemUpgradesEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ItemUpgradesResponse = z.input<typeof itemUpgradesEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/currentgame/CurrentGameLoadouts.ts
+++ b/valorant-api-types/src/endpoints/currentgame/CurrentGameLoadouts.ts
@@ -40,6 +40,6 @@ export const currentGameLoadoutsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CurrentGameLoadoutsResponse = z.input<typeof currentGameLoadoutsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/currentgame/CurrentGameMatch.ts
+++ b/valorant-api-types/src/endpoints/currentgame/CurrentGameMatch.ts
@@ -69,6 +69,6 @@ export const currentGameMatchEndpoint = {
             MatchmakingData: z.null()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CurrentGameMatchResponse = z.input<typeof currentGameMatchEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/currentgame/CurrentGamePlayer.ts
+++ b/valorant-api-types/src/endpoints/currentgame/CurrentGamePlayer.ts
@@ -20,6 +20,6 @@ export const currentGamePlayerEndpoint = {
             Version: z.number()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CurrentGamePlayerResponse = z.input<typeof currentGamePlayerEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/currentgame/CurrentGameQuit.ts
+++ b/valorant-api-types/src/endpoints/currentgame/CurrentGameQuit.ts
@@ -16,4 +16,4 @@ export const currentGameQuitEndpoint = {
     responses: {
         '204': z.undefined()
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/local/AccountAlias.ts
+++ b/valorant-api-types/src/endpoints/local/AccountAlias.ts
@@ -20,6 +20,6 @@ export const accountAliasEndpoint = {
             tag_line: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type AccountAliasResponse = z.input<typeof accountAliasEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/ChatSession.ts
+++ b/valorant-api-types/src/endpoints/local/ChatSession.ts
@@ -25,6 +25,6 @@ export const chatSessionEndpoint = {
             state: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ChatSessionResponse = z.input<typeof chatSessionEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/ClientRegion.ts
+++ b/valorant-api-types/src/endpoints/local/ClientRegion.ts
@@ -18,6 +18,6 @@ export const clientRegionEndpoint = {
             webRegion: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ClientRegionResponse = z.input<typeof clientRegionEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/EntitlementsToken.ts
+++ b/valorant-api-types/src/endpoints/local/EntitlementsToken.ts
@@ -21,6 +21,6 @@ export const entitlementsTokenEndpoint = {
             token: z.string().describe('Used as the entitlement in requests'),
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type EntitlementsTokenResponse = z.input<typeof entitlementsTokenEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/FriendRequests.ts
+++ b/valorant-api-types/src/endpoints/local/FriendRequests.ts
@@ -25,6 +25,6 @@ export const friendRequestsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type FriendRequestsResponse = z.input<typeof friendRequestsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/Friends.ts
+++ b/valorant-api-types/src/endpoints/local/Friends.ts
@@ -28,6 +28,6 @@ export const friendsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type FriendsResponse = z.input<typeof friendsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/LocalHelp.ts
+++ b/valorant-api-types/src/endpoints/local/LocalHelp.ts
@@ -17,6 +17,6 @@ export const localHelpEndpoint = {
             types: z.record(z.string().describe('Type name'), z.string().describe('Type description'))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type LocalHelpResponse = z.input<typeof localHelpEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/LocalSwaggerDocs.ts
+++ b/valorant-api-types/src/endpoints/local/LocalSwaggerDocs.ts
@@ -13,4 +13,4 @@ export const localSwaggerDocsEndpoint = {
     responses: {
         '200': z.unknown().describe('Swagger doc schema')
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/local/Presence.ts
+++ b/valorant-api-types/src/endpoints/local/Presence.ts
@@ -123,6 +123,6 @@ export const presenceEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PresenceResponse = z.input<typeof presenceEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/RSOUserInfo.ts
+++ b/valorant-api-types/src/endpoints/local/RSOUserInfo.ts
@@ -54,6 +54,6 @@ export const rsoUserInfoEndpoint = {
             userInfo: z.string().transform((str) => userInfoSchema.parse(JSON.parse(str)))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type RSOUserInfoResponse = z.input<typeof rsoUserInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/Sessions.ts
+++ b/valorant-api-types/src/endpoints/local/Sessions.ts
@@ -31,6 +31,6 @@ export const sessionsEndpoint = {
             version: z.string()
         }))
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SessionsResponse = z.input<typeof sessionsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/Settings.ts
+++ b/valorant-api-types/src/endpoints/local/Settings.ts
@@ -47,6 +47,6 @@ export const settingsEndpoint = {
             type: z.literal('Ares.PlayerSettings')
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SettingsResponse = z.input<typeof settingsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/AllChatInfo.ts
+++ b/valorant-api-types/src/endpoints/local/chat/AllChatInfo.ts
@@ -14,6 +14,6 @@ export const allChatInfoEndpoint = {
     responses: {
         '200': conversationsSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type AllChatInfoResponse = z.input<typeof allChatInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/ChatHistory.ts
+++ b/valorant-api-types/src/endpoints/local/chat/ChatHistory.ts
@@ -17,6 +17,6 @@ export const chatHistoryEndpoint = {
     responses: {
         '200': chatMessagesSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ChatHistoryResponse = z.input<typeof chatHistoryEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/ChatParticipants.ts
+++ b/valorant-api-types/src/endpoints/local/chat/ChatParticipants.ts
@@ -29,6 +29,6 @@ export const chatParticipantsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ChatParticipantsResponse = z.input<typeof chatParticipantsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/CurrentGameChatInfo.ts
+++ b/valorant-api-types/src/endpoints/local/chat/CurrentGameChatInfo.ts
@@ -14,6 +14,6 @@ export const currentGameChatInfoEndpoint = {
     responses: {
         '200': conversationsSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CurrentGameChatInfoResponse = z.input<typeof currentGameChatInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/PartyChatInfo.ts
+++ b/valorant-api-types/src/endpoints/local/chat/PartyChatInfo.ts
@@ -14,6 +14,6 @@ export const partyChatInfoEndpoint = {
     responses: {
         '200': conversationsSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyChatInfoResponse = z.input<typeof partyChatInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/PregameChatInfo.ts
+++ b/valorant-api-types/src/endpoints/local/chat/PregameChatInfo.ts
@@ -14,6 +14,6 @@ export const pregameChatInfoEndpoint = {
     responses: {
         '200': conversationsSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PregameChatInfoResponse = z.input<typeof pregameChatInfoEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/local/chat/SendChat.ts
+++ b/valorant-api-types/src/endpoints/local/chat/SendChat.ts
@@ -20,6 +20,6 @@ export const sendChatEndpoint = {
     responses: {
         '200': chatMessagesSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SendChatResponse = z.input<typeof sendChatEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/ChangeQueue.ts
+++ b/valorant-api-types/src/endpoints/party/ChangeQueue.ts
@@ -20,6 +20,6 @@ export const changeQueueEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ChangeQueueResponse = z.input<typeof changeQueueEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/CustomGameConfigs.ts
+++ b/valorant-api-types/src/endpoints/party/CustomGameConfigs.ts
@@ -59,6 +59,6 @@ export const customGameConfigsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CustomGameConfigsResponse = z.input<typeof customGameConfigsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/EnterMatchmakingQueue.ts
+++ b/valorant-api-types/src/endpoints/party/EnterMatchmakingQueue.ts
@@ -17,6 +17,6 @@ export const enterMatchmakingQueueEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type EnterMatchmakingQueueResponse = z.input<typeof enterMatchmakingQueueEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/LeaveMatchmakingQueue.ts
+++ b/valorant-api-types/src/endpoints/party/LeaveMatchmakingQueue.ts
@@ -17,6 +17,6 @@ export const leaveMatchmakingQueueEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type LeaveMatchmakingQueueResponse = z.input<typeof leaveMatchmakingQueueEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/Party.ts
+++ b/valorant-api-types/src/endpoints/party/Party.ts
@@ -16,6 +16,6 @@ export const partyEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyResponse = z.input<typeof partyEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyChatToken.ts
+++ b/valorant-api-types/src/endpoints/party/PartyChatToken.ts
@@ -18,6 +18,6 @@ export const partyChatTokenEndpoint = {
             Room: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyChatTokenResponse = z.input<typeof partyChatTokenEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyDecline.ts
+++ b/valorant-api-types/src/endpoints/party/PartyDecline.ts
@@ -20,6 +20,6 @@ export const partyDeclineEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyDeclineResponse = z.input<typeof partyDeclineEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyInvite.ts
+++ b/valorant-api-types/src/endpoints/party/PartyInvite.ts
@@ -22,6 +22,6 @@ export const partyInviteEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyInviteResponse = z.input<typeof partyInviteEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyPlayer.ts
+++ b/valorant-api-types/src/endpoints/party/PartyPlayer.ts
@@ -32,6 +32,6 @@ export const partyPlayerEndpoint = {
             PlatformInfo: platformSchema
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyPlayerResponse = z.input<typeof partyPlayerEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyRemovePlayer.ts
+++ b/valorant-api-types/src/endpoints/party/PartyRemovePlayer.ts
@@ -16,4 +16,4 @@ export const partyRemovePlayerEndpoint = {
     responses: {
         '204': z.undefined()
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/party/PartyRequest.ts
+++ b/valorant-api-types/src/endpoints/party/PartyRequest.ts
@@ -16,6 +16,6 @@ export const partyRequestEndpoint = {
     responses: {
         '200': z.unknown() //TODO verify
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyRequestResponse = z.input<typeof partyRequestEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartySetMemberReady.ts
+++ b/valorant-api-types/src/endpoints/party/PartySetMemberReady.ts
@@ -23,6 +23,6 @@ export const partySetMemberReadyEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartySetMemberReadyResponse = z.input<typeof partySetMemberReadyEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/PartyVoiceToken.ts
+++ b/valorant-api-types/src/endpoints/party/PartyVoiceToken.ts
@@ -18,6 +18,6 @@ export const partyVoiceTokenEndpoint = {
             Room: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PartyVoiceTokenResponse = z.input<typeof partyVoiceTokenEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/RefreshCompetitiveTier.ts
+++ b/valorant-api-types/src/endpoints/party/RefreshCompetitiveTier.ts
@@ -18,6 +18,6 @@ export const refreshCompetitiveTierEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type RefreshCompetitiveTierResponse = z.input<typeof refreshCompetitiveTierEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/RefreshPings.ts
+++ b/valorant-api-types/src/endpoints/party/RefreshPings.ts
@@ -18,6 +18,6 @@ export const refreshPingsEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type RefreshPingsResponse = z.input<typeof refreshPingsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/RefreshPlayerIdentity.ts
+++ b/valorant-api-types/src/endpoints/party/RefreshPlayerIdentity.ts
@@ -18,6 +18,6 @@ export const refreshPlayerIdentityEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type RefreshPlayerIdentityResponse = z.input<typeof refreshPlayerIdentityEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/SetCustomGameSettings.ts
+++ b/valorant-api-types/src/endpoints/party/SetCustomGameSettings.ts
@@ -31,6 +31,6 @@ export const setCustomGameSettingsEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SetCustomGameSettingsResponse = z.input<typeof setCustomGameSettingsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/SetPartyAccessibility.ts
+++ b/valorant-api-types/src/endpoints/party/SetPartyAccessibility.ts
@@ -20,6 +20,6 @@ export const setPartyAccessibilityEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SetPartyAccessibilityResponse = z.input<typeof setPartyAccessibilityEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/party/StartCustomGame.ts
+++ b/valorant-api-types/src/endpoints/party/StartCustomGame.ts
@@ -18,6 +18,6 @@ export const startCustomGameEndpoint = {
     responses: {
         '200': partySchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type StartCustomGameResponse = z.input<typeof startCustomGameEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pregame/LockCharacter.ts
+++ b/valorant-api-types/src/endpoints/pregame/LockCharacter.ts
@@ -22,6 +22,6 @@ export const lockCharacterEndpoint = {
     responses: {
         '200': pregameMatchSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type LockCharacterResponse = z.infer<typeof lockCharacterEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pregame/PregameLoadouts.ts
+++ b/valorant-api-types/src/endpoints/pregame/PregameLoadouts.ts
@@ -23,6 +23,6 @@ export const pregameLoadoutsEndpoint = {
             LoadoutsValid: z.literal(false)
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PregameLoadoutsResponse = z.infer<typeof pregameLoadoutsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pregame/PregameMatch.ts
+++ b/valorant-api-types/src/endpoints/pregame/PregameMatch.ts
@@ -16,6 +16,6 @@ export const pregameMatchEndpoint = {
     responses: {
         '200': pregameMatchSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PregameMatchResponse = z.infer<typeof pregameMatchEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pregame/PregamePlayer.ts
+++ b/valorant-api-types/src/endpoints/pregame/PregamePlayer.ts
@@ -20,6 +20,6 @@ export const pregamePlayerEndpoint = {
             Version: z.number()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PregamePlayerResponse = z.input<typeof pregamePlayerEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pregame/PregameQuit.ts
+++ b/valorant-api-types/src/endpoints/pregame/PregameQuit.ts
@@ -16,4 +16,4 @@ export const pregameQuitEndpoint = {
     responses: {
         '204': z.undefined()
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/pregame/SelectCharacter.ts
+++ b/valorant-api-types/src/endpoints/pregame/SelectCharacter.ts
@@ -22,6 +22,6 @@ export const selectCharacterEndpoint = {
     responses: {
         '200': pregameMatchSchema
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SelectCharacterResponse = z.infer<typeof selectCharacterEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/AccountXP.ts
+++ b/valorant-api-types/src/endpoints/pvp/AccountXP.ts
@@ -39,6 +39,6 @@ export const accountXPEndpoint = {
             NextTimeFirstWinAvailable: dateSchema
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type AccountXPResponse = z.input<typeof accountXPEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/CompetitiveUpdates.ts
+++ b/valorant-api-types/src/endpoints/pvp/CompetitiveUpdates.ts
@@ -39,6 +39,6 @@ export const competitiveUpdatesEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type CompetitiveUpdatesResponse = z.input<typeof competitiveUpdatesEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/Config.ts
+++ b/valorant-api-types/src/endpoints/pvp/Config.ts
@@ -143,6 +143,6 @@ export const configEndpoint = {
             })
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type ConfigEndpointResponse = z.input<typeof configEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/FetchContent.ts
+++ b/valorant-api-types/src/endpoints/pvp/FetchContent.ts
@@ -33,6 +33,6 @@ export const fetchContentEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type FetchContentResponse = z.input<typeof fetchContentEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/Leaderboard.ts
+++ b/valorant-api-types/src/endpoints/pvp/Leaderboard.ts
@@ -54,6 +54,6 @@ export const leaderboardEndpoint = {
             query: z.string()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type LeaderboardResponse = z.input<typeof leaderboardEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/MatchDetails.ts
+++ b/valorant-api-types/src/endpoints/pvp/MatchDetails.ts
@@ -216,6 +216,6 @@ export const matchDetailsEndpoint = {
             kills: z.array(killSchema),
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type MatchDetailsResponse = z.infer<typeof matchDetailsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/MatchHistory.ts
+++ b/valorant-api-types/src/endpoints/pvp/MatchHistory.ts
@@ -31,6 +31,6 @@ export const matchHistoryEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type MatchHistoryResponse = z.input<typeof matchHistoryEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/Penalties.ts
+++ b/valorant-api-types/src/endpoints/pvp/Penalties.ts
@@ -20,6 +20,6 @@ export const penaltiesEndpoint = {
             Version: z.number()
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PenaltiesResponse = z.input<typeof penaltiesEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/PlayerLoadout.ts
+++ b/valorant-api-types/src/endpoints/pvp/PlayerLoadout.ts
@@ -49,6 +49,6 @@ export const playerLoadoutEndpoint = {
             Version: z.number()
         }).merge(playerLoadoutSchema)
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PlayerLoadoutResponse = z.input<typeof playerLoadoutEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/PlayerMMR.ts
+++ b/valorant-api-types/src/endpoints/pvp/PlayerMMR.ts
@@ -64,6 +64,6 @@ export const playerMMREndpoint = {
         })
     }
 
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PlayerMMRResponse = z.input<typeof playerMMREndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/pvp/SetPlayerLoadout.ts
+++ b/valorant-api-types/src/endpoints/pvp/SetPlayerLoadout.ts
@@ -25,6 +25,6 @@ export const setPlayerLoadoutEndpoint = {
     variables: new Map([
         ['{loadout data}', playerLoadoutSchema.describe('JSON-encoded player loadout object. See the Player Loadout endpoint for an example. Exclude the Subject and Version properties.')]
     ])
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type SetPlayerLoadoutResponse = PlayerLoadoutResponse

--- a/valorant-api-types/src/endpoints/store/OwnedItems.ts
+++ b/valorant-api-types/src/endpoints/store/OwnedItems.ts
@@ -39,6 +39,6 @@ export const ownedItemsEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type OwnedItemsResponse = z.input<typeof ownedItemsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/store/Prices.ts
+++ b/valorant-api-types/src/endpoints/store/Prices.ts
@@ -28,6 +28,6 @@ export const pricesEndpoint = {
             }))
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type PricesResponse = z.input<typeof pricesEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/store/Storefront.ts
+++ b/valorant-api-types/src/endpoints/store/Storefront.ts
@@ -61,6 +61,6 @@ export const storefrontEndpoint = {
             }).optional().describe('Night market')
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type StorefrontResponse = z.input<typeof storefrontEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/store/Wallet.ts
+++ b/valorant-api-types/src/endpoints/store/Wallet.ts
@@ -17,6 +17,6 @@ export const walletEndpoint = {
             Balances: z.record(currencyIDSchema, z.number())
         })
     }
-} satisfies ValorantEndpoint
+} as const satisfies ValorantEndpoint
 
 export type WalletResponse = z.input<typeof walletEndpoint.responses['200']>


### PR DESCRIPTION
Allow to infer endpoints names, suffix etc at compile type rather than runtime