### PR TITLE
fix: winsByTier is nullable in MMR

### DIFF
--- a/valorant-api-types/src/endpoints/pvp/PlayerMMR.ts
+++ b/valorant-api-types/src/endpoints/pvp/PlayerMMR.ts
@@ -40,7 +40,7 @@ export const playerMMREndpoint = {
                             winsMap.set(parseInt(key), value)
                         }
                         return winsMap
-                    }),
+                    }).nullable(),
                     GamesNeededForRating: z.number(),
                     TotalWinsNeededForRank: z.number()
                 }))


### PR DESCRIPTION
Sample where parsing failed
```
{
...
       "573f53ac-41a5-3a7d-d9ce-d6a6298e5704": {
          "SeasonID": "573f53ac-41a5-3a7d-d9ce-d6a6298e5704",
          "NumberOfWins": 0,
          "NumberOfWinsWithPlacements": 0,
          "NumberOfGames": 1,
          "Rank": 0,
          "CapstoneWins": 0,
          "LeaderboardRank": 0,
          "CompetitiveTier": 0,
          "RankedRating": 0,
          "WinsByTier": null,
          "GamesNeededForRating": 0,
          "TotalWinsNeededForRank": 0
       },
...
}
```