### PR TITLE
fix: json header required by entitlement endpoint

### DIFF
--- a/valorant-api-types/src/endpoints/auth/Entitlement.ts
+++ b/valorant-api-types/src/endpoints/auth/Entitlement.ts
@@ -8,6 +8,9 @@ export const entitlementEndpoint = {
     type: 'other',
     suffix: 'https://entitlements.auth.riotgames.com/api/token/v1',
     method: 'POST',
+    headers: new Map([
+        ['Content-Type', 'application/json'],
+    ]),
     riotRequirements: {
         token: true
     },


### PR DESCRIPTION
With header:
```
data: {
    entitlements_token: blahblah...
}
```
Without header:
```
data: {
      httpStatus: 415,
      errorCode: 'WEB_APPLICATION',
      implementationDetails: 'filtered'
 }
```