### PR TITLE
feat(presences): add 'chat' to enum presences.state

### DIFF
--- a/valorant-api-types/src/endpoints/local/Presence.ts
+++ b/valorant-api-types/src/endpoints/local/Presence.ts
@@ -117,7 +117,7 @@ export const presenceEndpoint = {
                 puuid: playerUUIDSchema,
                 region: z.string(),
                 resource: z.string(),
-                state: z.enum(['mobile', 'dnd', 'away']),
+                state: z.enum(['mobile', 'dnd', 'away', 'chat']),
                 summary: z.string(),
                 time: millisSchema
             }))


### PR DESCRIPTION
I know the plan is to support only HTTP API for now. But i would like to propose an exception for this case as presences endpoint is heavily used in many applications with both Websocket and HTTP API.

This small change will help use the same Zod parser for both the cases(WS + HTTP), keeping a unified type signature

Presences response from WebSocket
```js
{
  presences: [
    {
      actor: null,
      basic: '',
      details: null,
      game_name: 'mrStark',
      game_tag: 'ODIN',
      location: null,
      msg: null,
      name: '',
      patchline: null,
      pid: 'fe0b384f-9c62-5ea8-960e-bbf92131e87c@sa3.pvp.net',
      platform: null,
      private: [Object],
      privateJwt: null,
      product: 'valorant',
      puuid: 'fe0b384f-9c62-5ea8-960e-bbf92131e87c',
      region: 'sa3',
      resource: 'RC-3828832804',
      state: 'chat', // <-- here is the change
      summary: '',
      time: 2023-07-12T13:23:07.312Z
    }
  ]
}
```