### PR TITLE
fix: add `X-Riot-ClientPlatform` requirement to party player endpoint

### DIFF
--- a/valorant-api-types/src/endpoints/party/PartyPlayer.ts
+++ b/valorant-api-types/src/endpoints/party/PartyPlayer.ts
@@ -12,7 +12,8 @@ export const partyPlayerEndpoint = {
     riotRequirements: {
         token: true,
         entitlement: true,
-        clientVersion: true
+        clientVersion: true,
+        clientPlatform: true
     },
     responses: {
         '200': partyPlayerSchema


### PR DESCRIPTION
As discussed here: https://discord.com/channels/723704236239618158/804405185178370098/1222335302111199402

> ...
> - Update [`Party_FetchPlayer`](https://valapidocs.techchrism.me/endpoint/party-player) to also require `X-Riot-ClientPlatform`
>
> ...